### PR TITLE
support influx write data

### DIFF
--- a/Microsoft-dashboard-grafana.json
+++ b/Microsoft-dashboard-grafana.json
@@ -1,0 +1,558 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_MICROSOFT",
+      "label": "Microsoft",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_MICROSOFT}"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "red",
+        "name": "New annotation",
+        "target": {
+          "fromAnnotations": true,
+          "query": "SHOW TAG VALUES WITH KEY = \"email\"",
+          "rawQuery": true,
+          "refId": "Anno",
+          "textEditor": true
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "New link",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_MICROSOFT}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Points"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 19,
+        "x": 0,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_MICROSOFT}"
+          },
+          "hide": false,
+          "query": "SELECT first(\"points\") AS \"Iniziale\" FROM \"microsoft\"..\"reward_points\" WHERE \"type\" = 'initial' AND $timeFilter GROUP BY \"email\"\n",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_MICROSOFT}"
+          },
+          "hide": false,
+          "query": "SELECT last(\"points\") AS \"Finale\" FROM \"microsoft\"..\"reward_points\" WHERE \"type\" = 'final' AND $timeFilter GROUP BY \"email\"\n",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "table"
+        }
+      ],
+      "title": "Gained Points",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "email",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Gained Points",
+            "binary": {
+              "left": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Finale"
+                }
+              },
+              "operator": "-",
+              "right": {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Iniziale"
+                }
+              }
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Gained Points": {
+                "aggregations": [
+                  "last"
+                ],
+                "operation": "aggregate"
+              },
+              "Time": {
+                "aggregations": [
+                  "last"
+                ]
+              },
+              "Time reward_points": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "email": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "email",
+            "rowField": "Time",
+            "valueField": "Gained Points (last)"
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_MICROSOFT}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "unit": "Points"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 26,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_MICROSOFT}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "email::tag"
+              ],
+              "type": "tag"
+            }
+          ],
+          "measurement": "reward_points",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "points"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "email::tag",
+              "operator": "=~",
+              "value": "/^$email$/"
+            }
+          ]
+        }
+      ],
+      "title": "Pie",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "${DS_MICROSOFT}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Points"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 16,
+        "w": 19,
+        "x": 0,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${DS_MICROSOFT}"
+          },
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "email::tag"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "previous"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "reward_points",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "points"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "email::tag",
+              "operator": "=~",
+              "value": "/^$email$/"
+            }
+          ]
+        }
+      ],
+      "title": "Time Points",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "influxdb",
+          "uid": "${DS_MICROSOFT}"
+        },
+        "definition": "SHOW TAG VALUES WITH KEY = \"email\"",
+        "includeAll": true,
+        "label": "Email",
+        "multi": true,
+        "name": "email",
+        "options": [],
+        "query": {
+          "query": "SHOW TAG VALUES WITH KEY = \"email\"",
+          "refId": "InfluxVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Microsoft",
+  "uid": "549452f0-0eac-4713-a9cb-4800d4a73f8c",
+  "version": 53,
+  "weekStart": ""
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@influxdata/influxdb-client": "^1.35.0",
     "axios": "^1.8.4",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0",
@@ -42,6 +43,7 @@
     "fingerprint-injector": "^2.1.66",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
+    "influx": "^5.10.0",
     "ms": "^2.1.3",
     "playwright": "1.52.0",
     "rebrowser-playwright": "1.52.0",

--- a/src/config.json
+++ b/src/config.json
@@ -43,5 +43,23 @@
     "webhook": {
         "enabled": false,
         "url": ""
-    }
+    },
+"influxdb": {
+  "version": 1,
+
+  "v1": {
+    "host": "localhost",
+    "port": 8086,
+    "protocol": "http",
+    "username": "tuo_username_v1",
+    "password": "tua_password_v1",
+    "database": "microsoft_rewards"
+  },
+  "v2": {
+    "url": "http://localhost:8086",
+    "token": "IL_TUO_TOKEN_V2",
+    "org": "la_tua_organizzazione",
+    "bucket": "microsoft_rewards"
+  }
+}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,3 +346,5 @@ main().catch(error => {
     log('main', 'MAIN-ERROR', `Error running bots: ${error}`, 'error')
     process.exit(1)
 })
+
+///////////////////////////////////////////

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import Activities from './functions/Activities'
 
 import { Account } from './interface/Account'
 import Axios from './util/Axios'
+import { writePoints } from './util/influx';
+
 
 
 // Main bot class
@@ -136,6 +138,7 @@ export class MicrosoftRewardsBot {
 
             log('main', 'MAIN-WORKER', `Completed tasks for account ${account.email}`, 'log', 'green')
         }
+        
 
         log(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')
         process.exit()
@@ -167,10 +170,22 @@ export class MicrosoftRewardsBot {
             + browserEnarablePoints.morePromotionsPoints
 
         log(this.isMobile, 'MAIN-POINTS', `You can earn ${this.pointsCanCollect} points today`)
+        
+            //influx//
+            if (typeof this.pointsInitial === 'number') {
+            writePoints(account, this.pointsInitial, this.log, 'initial');
+            }
+            
 
         // If runOnZeroPoints is false and 0 points to earn, don't continue
         if (!this.config.runOnZeroPoints && this.pointsCanCollect === 0) {
             log(this.isMobile, 'MAIN', 'No points to earn and "runOnZeroPoints" is set to "false", stopping!', 'log', 'yellow')
+
+                //influx//
+                if (typeof this.pointsInitial === 'number') {
+                writePoints(account, this.pointsInitial, this.log, 'final');
+                }
+            
 
             // Close desktop browser
             await this.browser.func.closeBrowser(browser, account.email)
@@ -215,6 +230,7 @@ export class MicrosoftRewardsBot {
     async Mobile(account: Account) {
         const browser = await this.browserFactory.createBrowser(account.proxy, account.email)
         this.homePage = await browser.newPage()
+        const afterPointAmount = await this.browser.func.getCurrentPoints()
 
         log(this.isMobile, 'MAIN', 'Starting browser')
 
@@ -233,11 +249,21 @@ export class MicrosoftRewardsBot {
 
         log(this.isMobile, 'MAIN-POINTS', `You can earn ${this.pointsCanCollect} points today (Browser: ${browserEnarablePoints.mobileSearchPoints} points, App: ${appEarnablePoints.totalEarnablePoints} points)`)
 
+        //influx//
+            if (typeof afterPointAmount === 'number') {
+            writePoints(account, this.pointsInitial, this.log, 'initial');
+            }
+
         // If runOnZeroPoints is false and 0 points to earn, don't continue
         if (!this.config.runOnZeroPoints && this.pointsCanCollect === 0) {
             log(this.isMobile, 'MAIN', 'No points to earn and "runOnZeroPoints" is set to "false", stopping!', 'log', 'yellow')
 
-            // Close mobile browser
+            //influx//
+                if (typeof afterPointAmount === 'number') {
+                writePoints(account, afterPointAmount, this.log, 'final');
+                }
+
+        // Close mobile browser
             await this.browser.func.closeBrowser(browser, account.email)
             return
         }
@@ -290,9 +316,12 @@ export class MicrosoftRewardsBot {
             }
         }
 
-        const afterPointAmount = await this.browser.func.getCurrentPoints()
-
         log(this.isMobile, 'MAIN-POINTS', `The script collected ${afterPointAmount - this.pointsInitial} points today`)
+
+        //influx//
+            if (typeof afterPointAmount === 'number') {
+            writePoints(account, afterPointAmount, this.log, 'final');
+            }
 
         // Close mobile browser
         await this.browser.func.closeBrowser(browser, account.email)

--- a/src/util/influx.ts
+++ b/src/util/influx.ts
@@ -1,0 +1,68 @@
+import { InfluxDB, Point } from '@influxdata/influxdb-client';
+import * as InfluxV1 from 'influx';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { Account } from '../interface/Account';
+import { log } from './Logger';
+type LogFunction = typeof log;
+
+const configPath = path.join(__dirname, 'config.json');
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+const influxConfig = config.influxdb;
+
+let influxClient: any;
+let isV2 = false;
+
+// Logica di selezione della versione
+if (influxConfig?.version && influxConfig.version !== 0) {
+    if (influxConfig.version === 2) {
+        isV2 = true;
+        const { url, token, org, bucket } = influxConfig.v2;
+        if (url && token && org && bucket) {
+            influxClient = new InfluxDB({ url, token }).getWriteApi(org, bucket);
+            log(false, 'INFLUXDB', 'InfluxDB v2 client initialized.');
+        }
+    } else if (influxConfig.version === 1) {
+        isV2 = false;
+        const { host, database } = influxConfig.v1;
+        if (host && database) {
+            influxClient = new InfluxV1.InfluxDB(influxConfig.v1);
+            log(false, 'INFLUXDB', 'InfluxDB v1 client initialized.');
+        }
+    }
+}
+
+/**
+ * Scrive i punti correnti su InfluxDB
+ */
+export async function writePoints(account: Account, points: number, log: LogFunction, pointType: 'initial' | 'final') {
+    // Il controllo corretto che non usa la variabile "isEnabled"
+    if (!influxConfig?.version || influxConfig.version === 0 || !influxClient) {
+        return;
+    }
+
+    const versionType = isV2 ? 'v2' : 'v1';
+
+    try {
+        if (isV2) {
+            const dataPoint = new Point('reward_points')
+                .tag('email', account.email)
+                .tag('type', pointType)
+                .intField('points', points);
+            influxClient.writePoint(dataPoint);
+            await influxClient.flush();
+        } else {
+            await influxClient.writePoints([{
+                measurement: 'reward_points',
+                tags: { email: account.email, type: pointType },
+                fields: { points: points },
+            }]);
+        }
+        log(false, 'INFLUXDB', `Successfully wrote ${points} points for ${account.email} (${pointType}) to InfluxDB (${versionType}).`);
+    } catch (error) {
+        const errorDetails = JSON.stringify(error, Object.getOwnPropertyNames(error), 2);
+        log(false, 'INFLUXDB', `Error writing to InfluxDB: ${errorDetails}`, 'error');
+    }
+}


### PR DESCRIPTION
## Riepilogo di Sourcery

Aggiunge l'integrazione InfluxDB per registrare le metriche dei punti premio e include una configurazione per la dashboard di Grafana

Nuove funzionalità:
- Introduce l'utility `writePoints` per registrare i punti premio iniziali e finali su InfluxDB
- Richiama `writePoints` nei flussi di lavoro desktop e mobile per acquisire i dati delle metriche

Miglioramenti:
- Supporta sia i client InfluxDB v1 che v2 in base alla configurazione

Build:
- Aggiunge le dipendenze `@influxdata/influxdb-client` e `influx`

Documentazione:
- Fornisce `Microsoft-dashboard-grafana.json` per la visualizzazione in Grafana

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add InfluxDB integration to record reward point metrics and include a Grafana dashboard configuration

New Features:
- Introduce writePoints utility to log initial and final reward points to InfluxDB
- Invoke writePoints in desktop and mobile workflows to capture metric data

Enhancements:
- Support both InfluxDB v1 and v2 clients based on configuration

Build:
- Add @influxdata/influxdb-client and influx dependencies

Documentation:
- Provide Microsoft-dashboard-grafana.json for Grafana visualization

</details>